### PR TITLE
Update conclusion

### DIFF
--- a/content/50_Conclusion/_index.md
+++ b/content/50_Conclusion/_index.md
@@ -13,7 +13,7 @@ In this workshop you have:
 
 But this is only the beginning. Redis can do much more! For example:
 
-* Redis can count very [large numbers of distinct items in constant space] (great for determining if a user has every logged in before, or if an IP address has ever been used before); 
+* Redis can count very [large numbers of distinct items in constant space] - great for determining if a user has every logged in before, or if an IP address has ever been used before; 
 * Redis can provide [synchronous messaging] between clients (think of game servers, each serving thousands of users, but needing to rapidly send messages about user's status etc. from one server to another)
 * Redis can [implement leaderboards] very efficiently; something that SQL really struggles to do!
 * Redis supports [geospatial] indexes, so you can easily provide sophisticated mapping interfaces to users


### PR DESCRIPTION
URL was being incorrectly calculated. I suspect it was because a reference using square brackets was followed by a sentence using parentheses, and the parser was interpreting this as a full [anchor](url) expression.

The fix is (I believe) to simply remove the parentheses.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
